### PR TITLE
Fixing breakage for kernel version 6.10 or above

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,8 @@ KOUTPUT_MAKEFILE := $(KOUTPUT)/Makefile
 
 all: $(KOUTPUT_MAKEFILE)
 	@echo "$(KOUTPUT)"
-	make -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/memflow-kmod clean
+	
 	make -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/memflow-kmod modules
-	mv $(PWD)/memflow-kmod/memflow.ko ./build/
 
 $(KOUTPUT):
 	mkdir -p "$@"

--- a/Makefile
+++ b/Makefile
@@ -1,49 +1,35 @@
-# Define the source directory
-SRC_DIR := memflow-kmod
+obj-y += memflow-kmod/
 
-# Define the build directory
-BUILD_DIR := build
+MCFLAGS += -O3
+ccflags-y += ${MCFLAGS}
+CC += ${MCFLAGS}
 
-# Define the object files
-obj-m := $(MODULE_NAME).o
-$(MODULE_NAME)-objs := $(patsubst %.c,%.o,$(wildcard $(SRC_DIR)/*.c))
-
-# Compiler flags
-MCFLAGS := -O3
-ccflags-y += $(MCFLAGS)
-CC += $(MCFLAGS)
-
-# Kernel directory
 ifndef KERNELDIR
-KDIR := /lib/modules/$(shell uname -r)/build
+	KDIR := /lib/modules/$(shell uname -r)/build
 else
-KDIR := $(KERNELDIR)
+	KDIR := $(KERNELDIR)
 endif
 
-# Output directory
 ifndef OUT_DIR
-KOUTPUT := $(PWD)/$(BUILD_DIR)
+	KOUTPUT := $(PWD)/build
 else
-KOUTPUT := $(OUT_DIR)
+	KOUTPUT := $(OUT_DIR)
 endif
 
-# Default target
-all: $(KOUTPUT)/$(MODULE_NAME).ko
+KOUTPUT_MAKEFILE := $(KOUTPUT)/Makefile
 
-# Build the kernel module
-$(KOUTPUT)/$(MODULE_NAME).ko: $(KOUTPUT)
-	@echo "Building kernel module in $(KOUTPUT)"
-	$(MAKE) -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/$(SRC_DIR) modules
-	@echo "Copying object files to $(KOUTPUT)"
-	cp $(SRC_DIR)/*.o $(KOUTPUT)/
+all: $(KOUTPUT_MAKEFILE)
+	@echo "$(KOUTPUT)"
 
-# Create the build directory
+	make -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/memflow-kmod modules
+
 $(KOUTPUT):
-	mkdir -p $@
+	mkdir -p "$@"
 
-# Clean target
+$(KOUTPUT_MAKEFILE): $(KOUTPUT)
+	touch "$@"
+
 clean:
-	$(MAKE) -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/$(SRC_DIR) clean
-	rm -rf $(KOUTPUT)
-
-.PHONY: all clean
+	make -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/memflow-kmod clean
+	$(shell rm $(KOUTPUT_MAKEFILE))
+	rmdir $(KOUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ all: $(KOUTPUT_MAKEFILE)
 	@echo "$(KOUTPUT)"
 
 	make -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/memflow-kmod modules
+	mv $(PWD)/memflow-kmod/memflow.ko ./build/
 
 $(KOUTPUT):
 	mkdir -p "$@"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ KOUTPUT_MAKEFILE := $(KOUTPUT)/Makefile
 
 all: $(KOUTPUT_MAKEFILE)
 	@echo "$(KOUTPUT)"
-
+	make -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/memflow-kmod clean
 	make -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/memflow-kmod modules
 	mv $(PWD)/memflow-kmod/memflow.ko ./build/
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ KOUTPUT_MAKEFILE := $(KOUTPUT)/Makefile
 
 all: $(KOUTPUT_MAKEFILE)
 	@echo "$(KOUTPUT)"
-	
+
 	make -C $(KDIR) M=$(KOUTPUT) src=$(PWD)/memflow-kmod modules
 
 $(KOUTPUT):

--- a/memflow-kmod/vmtools.c
+++ b/memflow-kmod/vmtools.c
@@ -321,8 +321,12 @@ do_return:
 
 static unsigned long memflow_vm_mem_get_unmapped_area(struct file *file, unsigned long addr, unsigned long len, unsigned long pgoff, unsigned long flags)
 {
-	struct vm_mem_data *data = file->private_data;
-	return get_unmapped_area(data->wrapped_vma->vm_file, addr, len, pgoff + data->wrapped_vma->vm_pgoff, flags);
+    struct vm_mem_data *data = file->private_data;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,10,0)
+    return get_unmapped_area(data->wrapped_vma->vm_file, addr, len, pgoff + data->wrapped_vma->vm_pgoff, flags);
+#else
+    return mm_get_unmapped_area(data->wrapped_task->mm, data->wrapped_vma->vm_file, addr, len, pgoff + data->wrapped_vma->vm_pgoff, flags);
+#endif
 }
 
 static const struct file_operations memflow_vm_mem_fops = {


### PR DESCRIPTION
Here's a brief commit message on the kernel change this PR is accounting for:

> "Recently the get_unmapped_area() pointer on mm_struct was removed in
> favor of direct callable function that can determines which of two
> handlers to call based on an mm flag. This function,
> mm_get_unmapped_area(), checks the flag of the mm passed as an argument."
> 

https://patchwork.kernel.org/project/linux-mm/patch/20240506160747.1321726-1-rick.p.edgecombe@intel.com/

